### PR TITLE
Use warnings instead of prints in krn parser

### DIFF
--- a/apps/generation.lisp
+++ b/apps/generation.lisp
@@ -2,7 +2,7 @@
 ;;;; File:       generation.lisp
 ;;;; Author:     Marcus Pearce <marcus.pearce@qmul.ac.uk>
 ;;;; Created:    <2003-08-21 18:54:17 marcusp>                           
-;;;; Time-stamp: <2020-04-13 15:39:45 marcusp>                           
+;;;; Time-stamp: <2020-05-18 16:09:28 marcusp>                           
 ;;;; ======================================================================
 ;;;;
 ;;;; DESCRIPTION 
@@ -42,12 +42,11 @@
                            (events nil)
                            (position :backward)
                            pretraining-ids
-                           description
                            (random-state cl:*random-state*)
                            (threshold nil)
                            (use-ltms-cache? t)
-                           (output-file-path nil))
-  (declare (ignorable description output-file-path))
+                           (output-filename nil)
+                           (output-path nil))
   (mvs:set-models models)
   (initialise-prediction-cache dataset-id attributes)
   (let* ((dataset (md:get-event-sequences (list dataset-id)))
@@ -75,8 +74,8 @@
             (otherwise (metropolis-sampling mvs (car test-set) iterations random-state threshold)))))
     ;; (write-prediction-cache-to-file dataset-id attributes)
     ;; (print (viewpoints:viewpoint-sequence (viewpoints:get-viewpoint 'cpitch) sequence))
-    (when (and output-file-path sequence)
-      (md:export-data sequence :mid output-file-path))
+    (when (and output-path sequence)
+      (md:export-data sequence :mid output-path output-filename))
     sequence))
 
 (defun get-pretraining-set (dataset-ids)

--- a/database/data-import/kern2db.lisp
+++ b/database/data-import/kern2db.lisp
@@ -176,10 +176,10 @@
 (defun print-status ()
   "Print message warning about unrecognised representations or tokens."
   (unless (null *unrecognised-representations*)
-    (format t "~%The following representations were unrecognised: ~S"
+    (warn "~%The following representations were unrecognised: ~S"
             *unrecognised-representations*))
   (unless (null *unrecognised-tokens*)
-    (format t "~%The following tokens were unrecognised: ~S"
+    (warn "~%The following tokens were unrecognised: ~S"
             *unrecognised-tokens*)))
 
 
@@ -535,7 +535,7 @@
                               ((and (= p1 0) (= p2 0))
                                0)
                               (t 
-                               (print "Warning: unexpected phrase token within tied note.")
+                               (warn "Warning: unexpected phrase token within tied note.")
                                -1))))))
                 
 (defun update-environment (environment token type)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,4 @@
+title: IDyOM
+description: Information Dynamics of Music 
+downloads: false
 theme: jekyll-theme-minimal

--- a/music-objects/midi.lisp
+++ b/music-objects/midi.lisp
@@ -2,7 +2,7 @@
 ;;;; File:       midi.lisp
 ;;;; Author:     Marcus Pearce <marcus.pearce@qmul.ac.uk>
 ;;;; Created:    <2020-02-05 07:01:51 marcusp>
-;;;; Time-stamp: <2020-05-18 15:52:16 marcusp>
+;;;; Time-stamp: <2020-05-18 16:09:24 marcusp>
 ;;;; ======================================================================
 
 (cl:in-package #:music-data)
@@ -17,17 +17,16 @@
 
 ;;; Export data
 
-(defgeneric export-data (events type path))
+(defgeneric export-data (events type path &optional filename))
 
-(defmethod export-data ((event-list list) (type (eql :mid)) path)
-  "Export a list of events, which may be database events (mtp-event)
-or music objects events (music-event)."
+(defmethod export-data ((event-list list) (type (eql :mid)) path &optional filename)
+  "Export a list of music objects events (music-event)."
   (let* ((first-event (car event-list))
          (id (md:get-identifier first-event))
          (did (md:get-dataset-index id))
          (cid (md:get-composition-index id))
          (description (idyom-db:get-description did cid))
-         (filename (concatenate 'string path "/" description ".mid")))
+         (filename (if filename filename (concatenate 'string path "/" description ".mid"))))
     (print filename)
     (mo-events->midi event-list filename)))
 

--- a/music-objects/midi.lisp
+++ b/music-objects/midi.lisp
@@ -2,7 +2,7 @@
 ;;;; File:       midi.lisp
 ;;;; Author:     Marcus Pearce <marcus.pearce@qmul.ac.uk>
 ;;;; Created:    <2020-02-05 07:01:51 marcusp>
-;;;; Time-stamp: <2020-05-18 16:09:24 marcusp>
+;;;; Time-stamp: <2020-07-10 09:33:42 marcusp>
 ;;;; ======================================================================
 
 (cl:in-package #:music-data)
@@ -19,6 +19,9 @@
 
 (defgeneric export-data (events type path &optional filename))
 
+(defmethod export-data ((mo music-object) (type (eql :mid)) path &optional filename)
+  (export-data (coerce mo 'list) type path filename))
+                                                                  
 (defmethod export-data ((event-list list) (type (eql :mid)) path &optional filename)
   "Export a list of music objects events (music-event)."
   (let* ((first-event (car event-list))
@@ -26,7 +29,7 @@
          (did (md:get-dataset-index id))
          (cid (md:get-composition-index id))
          (description (idyom-db:get-description did cid))
-         (filename (if filename filename (concatenate 'string path "/" description ".mid"))))
+         (filename (concatenate 'string path "/" (if filename filename description) ".mid")))
     (print filename)
     (mo-events->midi event-list filename)))
 
@@ -40,8 +43,10 @@
          (tempo (md:get-attribute (car events) :tempo))
          (keysig (md:get-attribute (car events) :keysig))
          (mode (md:get-attribute (car events) :mode))
+         (mode (when mode (if (= mode 9) 1 0)))
          (pulses (md:get-attribute (car events) :pulses))
          (barlength (md:get-attribute (car events) :barlength))
+         (midi-dd (when (and pulses barlength) (round (- (log (/ barlength (* pulses *timebase*)) 2)))))
          ;; channel
          (channel-msg (make-instance 'midi:program-change-message :time 0 
                                      :status (+ #xc0 channel) 
@@ -56,18 +61,25 @@
                                     :status #xff))
          ;; timesig
          (timesig-msg (make-instance 'midi:time-signature-message :time 0
-                                     :status #xff)))
-    (setf (slot-value keysig-msg 'midi::sf) keysig
-          (slot-value keysig-msg 'midi::mi) (if (= mode 9) 1 0)
-          (slot-value timesig-msg 'midi::nn) pulses
-          (slot-value timesig-msg 'midi::dd) (round (- (log (/ barlength (* pulses *timebase*)) 2)))
-          (slot-value timesig-msg 'midi::cc) 0
-          (slot-value timesig-msg 'midi::bb) 8)
-    (let* ((track (mapcan #'mo-event->midi events))
-           (midifile (make-instance 'midi:midifile
-                                    :format format
-                                    :division (* (/ *timebase* 4) *tick-multiplier*)
-                                    :tracks (list (append (list tempo-msg timesig-msg keysig-msg channel-msg) track)))))
+                                     :status #xff))
+         ;; midi track
+         (track (mapcan #'mo-event->midi events)))
+    (push channel-msg track)
+    (when (and keysig mode)
+      (setf (slot-value keysig-msg 'midi::sf) keysig
+            (slot-value keysig-msg 'midi::mi) mode)
+      (push keysig-msg track))
+    (when midi-dd
+      (setf (slot-value timesig-msg 'midi::nn) pulses
+            (slot-value timesig-msg 'midi::dd) midi-dd
+            (slot-value timesig-msg 'midi::cc) 0
+            (slot-value timesig-msg 'midi::bb) 8)
+      (push timesig-msg track))
+    (push tempo-msg track)
+    (let ((midifile (make-instance 'midi:midifile
+                                   :format format
+                                   :division (* (/ *timebase* 4) *tick-multiplier*)
+                                   :tracks (list track))))
       (midi:write-midi-file midifile file)
       midifile)))
 


### PR DESCRIPTION
I am using IDyOM's krn parser in a script that creates CSV representations of krn files. Because I am piping the output of this script into a CSV file I want to be able to dissociate printed output from warnings. The `warn` function writes to stderr while `print` writes to stdout, so using warn solves this problem. It seems appropriate to use warn anyway, since these really are warnings.