### PR TITLE
Use warnings instead of prints in krn parser

### DIFF
--- a/database/data-import/kern2db.lisp
+++ b/database/data-import/kern2db.lisp
@@ -176,10 +176,10 @@
 (defun print-status ()
   "Print message warning about unrecognised representations or tokens."
   (unless (null *unrecognised-representations*)
-    (format t "~%The following representations were unrecognised: ~S"
+    (warn "~%The following representations were unrecognised: ~S"
             *unrecognised-representations*))
   (unless (null *unrecognised-tokens*)
-    (format t "~%The following tokens were unrecognised: ~S"
+    (warn "~%The following tokens were unrecognised: ~S"
             *unrecognised-tokens*)))
 
 
@@ -535,7 +535,7 @@
                               ((and (= p1 0) (= p2 0))
                                0)
                               (t 
-                               (print "Warning: unexpected phrase token within tied note.")
+                               (warn "Warning: unexpected phrase token within tied note.")
                                -1))))))
                 
 (defun update-environment (environment token type)


### PR DESCRIPTION
I am using IDyOM's krn parser in a script that creates CSV representations of krn files. Because I am piping the output of this script into a CSV file I want to be able to dissociate printed output from warnings. The warn function writes to stderr while print writes to stdout, so using warn solves this problem. It seems appropriate to use warn anyway, since these really are warnings.