### PR TITLE
Disallow MFREI in krn files

### DIFF
--- a/database/data-import/kern2db.lisp
+++ b/database/data-import/kern2db.lisp
@@ -93,7 +93,7 @@
             ("^\\*I[^ T G C]" voice)                ;process instrument token
             ("^\\*k\\[[a-g]?" keysig)               ;process keysig token
             ("^\\*[a-g A-G ? X]" mode)              ;process mode token
-            ("^\\*M(FREI)?[0-9 ? X Z]" timesig)     ;process timesig token
+            ("^\\*M[0-9 ? X Z]" timesig)            ;process timesig token
             ("^\\*tb" ignore-token))))              ;ignore timebase token
   
 (defvar *voice-alist* '())


### PR DESCRIPTION
I think I did this because it caused problems in the calculation of the onset time of the first note.