### PR TITLE
Creating and initializing PPM instances with MAKE-INSTANCE

### DIFF
--- a/apps/generation.lisp
+++ b/apps/generation.lisp
@@ -2,7 +2,7 @@
 ;;;; File:       generation.lisp
 ;;;; Author:     Marcus Pearce <marcus.pearce@qmul.ac.uk>
 ;;;; Created:    <2003-08-21 18:54:17 marcusp>                           
-;;;; Time-stamp: <2020-04-13 15:39:45 marcusp>                           
+;;;; Time-stamp: <2020-05-18 16:09:28 marcusp>                           
 ;;;; ======================================================================
 ;;;;
 ;;;; DESCRIPTION 
@@ -42,12 +42,11 @@
                            (events nil)
                            (position :backward)
                            pretraining-ids
-                           description
                            (random-state cl:*random-state*)
                            (threshold nil)
                            (use-ltms-cache? t)
-                           (output-file-path nil))
-  (declare (ignorable description output-file-path))
+                           (output-filename nil)
+                           (output-path nil))
   (mvs:set-models models)
   (initialise-prediction-cache dataset-id attributes)
   (let* ((dataset (md:get-event-sequences (list dataset-id)))
@@ -75,8 +74,8 @@
             (otherwise (metropolis-sampling mvs (car test-set) iterations random-state threshold)))))
     ;; (write-prediction-cache-to-file dataset-id attributes)
     ;; (print (viewpoints:viewpoint-sequence (viewpoints:get-viewpoint 'cpitch) sequence))
-    (when (and output-file-path sequence)
-      (md:export-data sequence :mid output-file-path))
+    (when (and output-path sequence)
+      (md:export-data sequence :mid output-path output-filename))
     sequence))
 
 (defun get-pretraining-set (dataset-ids)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,4 @@
+title: IDyOM
+description: Information Dynamics of Music 
+downloads: false
 theme: jekyll-theme-minimal

--- a/music-objects/midi.lisp
+++ b/music-objects/midi.lisp
@@ -2,7 +2,7 @@
 ;;;; File:       midi.lisp
 ;;;; Author:     Marcus Pearce <marcus.pearce@qmul.ac.uk>
 ;;;; Created:    <2020-02-05 07:01:51 marcusp>
-;;;; Time-stamp: <2020-05-18 15:52:16 marcusp>
+;;;; Time-stamp: <2020-05-18 16:09:24 marcusp>
 ;;;; ======================================================================
 
 (cl:in-package #:music-data)
@@ -17,17 +17,16 @@
 
 ;;; Export data
 
-(defgeneric export-data (events type path))
+(defgeneric export-data (events type path &optional filename))
 
-(defmethod export-data ((event-list list) (type (eql :mid)) path)
-  "Export a list of events, which may be database events (mtp-event)
-or music objects events (music-event)."
+(defmethod export-data ((event-list list) (type (eql :mid)) path &optional filename)
+  "Export a list of music objects events (music-event)."
   (let* ((first-event (car event-list))
          (id (md:get-identifier first-event))
          (did (md:get-dataset-index id))
          (cid (md:get-composition-index id))
          (description (idyom-db:get-description did cid))
-         (filename (concatenate 'string path "/" description ".mid")))
+         (filename (if filename filename (concatenate 'string path "/" description ".mid"))))
     (print filename)
     (mo-events->midi event-list filename)))
 

--- a/music-objects/midi.lisp
+++ b/music-objects/midi.lisp
@@ -2,7 +2,7 @@
 ;;;; File:       midi.lisp
 ;;;; Author:     Marcus Pearce <marcus.pearce@qmul.ac.uk>
 ;;;; Created:    <2020-02-05 07:01:51 marcusp>
-;;;; Time-stamp: <2020-05-18 16:09:24 marcusp>
+;;;; Time-stamp: <2020-07-10 09:33:42 marcusp>
 ;;;; ======================================================================
 
 (cl:in-package #:music-data)
@@ -19,6 +19,9 @@
 
 (defgeneric export-data (events type path &optional filename))
 
+(defmethod export-data ((mo music-object) (type (eql :mid)) path &optional filename)
+  (export-data (coerce mo 'list) type path filename))
+                                                                  
 (defmethod export-data ((event-list list) (type (eql :mid)) path &optional filename)
   "Export a list of music objects events (music-event)."
   (let* ((first-event (car event-list))
@@ -26,7 +29,7 @@
          (did (md:get-dataset-index id))
          (cid (md:get-composition-index id))
          (description (idyom-db:get-description did cid))
-         (filename (if filename filename (concatenate 'string path "/" description ".mid"))))
+         (filename (concatenate 'string path "/" (if filename filename description) ".mid")))
     (print filename)
     (mo-events->midi event-list filename)))
 
@@ -40,8 +43,10 @@
          (tempo (md:get-attribute (car events) :tempo))
          (keysig (md:get-attribute (car events) :keysig))
          (mode (md:get-attribute (car events) :mode))
+         (mode (when mode (if (= mode 9) 1 0)))
          (pulses (md:get-attribute (car events) :pulses))
          (barlength (md:get-attribute (car events) :barlength))
+         (midi-dd (when (and pulses barlength) (round (- (log (/ barlength (* pulses *timebase*)) 2)))))
          ;; channel
          (channel-msg (make-instance 'midi:program-change-message :time 0 
                                      :status (+ #xc0 channel) 
@@ -56,18 +61,25 @@
                                     :status #xff))
          ;; timesig
          (timesig-msg (make-instance 'midi:time-signature-message :time 0
-                                     :status #xff)))
-    (setf (slot-value keysig-msg 'midi::sf) keysig
-          (slot-value keysig-msg 'midi::mi) (if (= mode 9) 1 0)
-          (slot-value timesig-msg 'midi::nn) pulses
-          (slot-value timesig-msg 'midi::dd) (round (- (log (/ barlength (* pulses *timebase*)) 2)))
-          (slot-value timesig-msg 'midi::cc) 0
-          (slot-value timesig-msg 'midi::bb) 8)
-    (let* ((track (mapcan #'mo-event->midi events))
-           (midifile (make-instance 'midi:midifile
-                                    :format format
-                                    :division (* (/ *timebase* 4) *tick-multiplier*)
-                                    :tracks (list (append (list tempo-msg timesig-msg keysig-msg channel-msg) track)))))
+                                     :status #xff))
+         ;; midi track
+         (track (mapcan #'mo-event->midi events)))
+    (push channel-msg track)
+    (when (and keysig mode)
+      (setf (slot-value keysig-msg 'midi::sf) keysig
+            (slot-value keysig-msg 'midi::mi) mode)
+      (push keysig-msg track))
+    (when midi-dd
+      (setf (slot-value timesig-msg 'midi::nn) pulses
+            (slot-value timesig-msg 'midi::dd) midi-dd
+            (slot-value timesig-msg 'midi::cc) 0
+            (slot-value timesig-msg 'midi::bb) 8)
+      (push timesig-msg track))
+    (push tempo-msg track)
+    (let ((midifile (make-instance 'midi:midifile
+                                   :format format
+                                   :division (* (/ *timebase* 4) *tick-multiplier*)
+                                   :tracks (list track))))
       (midi:write-midi-file midifile file)
       midifile)))
 

--- a/mvs/multiple-viewpoint-system.lisp
+++ b/mvs/multiple-viewpoint-system.lisp
@@ -291,8 +291,9 @@ objects."
   "Returns a vector of freshly initialised ppm short term models
 corresponding to the supplied list of viewpoints and initialised with
 the supplied parameters."
-  (apply #'vector (mapcar #'(lambda (v) (make-ppm (viewpoint-alphabet v)))
-                          viewpoints)))
+  (apply #'vector (mapcar #'(lambda (v) (make-instance 'ppm:ppm :alphabet
+						       (viewpoint-alphabet v)))
+			  viewpoints)))
 
 
 ;;;========================================================================

--- a/ppm-star/ppm-io.lisp
+++ b/ppm-star/ppm-io.lisp
@@ -50,7 +50,7 @@
    <filename> exists the model is read from the designated file otherwise
    it is constructed from the database and written to <filename>." 
   (unless (utils:file-exists filename)
-    (let ((model (make-ppm alphabet)))
+    (let ((model (make-instance 'ppm :alphabet alphabet)))
       (model-dataset model dataset :construct? t :predict? nil)
       (write-model-to-file model filename)
       (format t "~&Written PPM* model to ~A.~%" filename)))
@@ -66,9 +66,10 @@
          (branches (utils:alist->hash-table (nth 1 (assoc 'branches model))))
          (dataset (alist->dataset (nth 1 (assoc 'dataset model))))
          (alphabet (nth 1 (assoc 'alphabet model))))
-    (make-ppm alphabet :leaves leaves :branches branches :dataset dataset
-              :order-bound order-bound :mixtures mixtures :escape escape
-              :update-exclusion update-exclusion)))
+    (make-instance 'ppm :alphabet alphabet :leaves leaves
+		   :branches branches :dataset dataset
+		   :order-bound order-bound :mixtures mixtures :escape escape
+		   :update-exclusion update-exclusion)))
               
 
 (defmethod write-model-to-file ((m ppm) filename)

--- a/ppm-star/ppm-ui.lisp
+++ b/ppm-star/ppm-ui.lisp
@@ -93,7 +93,7 @@
 
 (defun build-model (sequences alphabet)
   "Train a PPM* model on <sequences> composed from the specified <alphabet>."
-  (let ((model (ppm:make-ppm alphabet :escape :c :mixtures t
+  (let ((model (make-instance 'ppm:ppm :alphabet alphabet :escape :c :mixtures t 
                              :update-exclusion nil :order-bound nil)))
     (ppm:model-dataset model sequences :construct? t :predict? nil)
     model))


### PR DESCRIPTION
This PR allows PPM models to be created and initialized using make-instance. It also makes it possible to define the default values of the PPM parameters in the class definition (as is done in this PR). This is arguably a bit clearer as it is less ambiguous where these defaults should be defined.

This is one of the changes that jackdaw actually does rely on.